### PR TITLE
Feature: Get route by name

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -324,4 +324,20 @@ class Router extends Core
 
         return header("location: $route$data");
     }
+
+    /**
+     * Get route url by defined route name
+     *
+     * @param string $routeName
+     *
+     * @return string
+     */
+    public static function route(string $routeName): string
+    {
+        if (!isset(static::$namedRoutes[$routeName])) {
+            trigger_error('Route named ' . $routeName . ' not found');
+        }
+
+        return static::$namedRoutes[$routeName];
+    }
 }

--- a/tests/routes.test.php
+++ b/tests/routes.test.php
@@ -108,3 +108,18 @@ test('delete route', function () {
 
     expect(TRoute::$val)->toBe(false);
 });
+
+test('route should return url by route name', function () {
+    $router = new Router;
+    $router->match('GET', '/route/url', ['handler', 'name' => 'route-name']);
+
+    $routeUrl = $router->route('route-name');
+
+    expect($routeUrl)->toBe('/route/url');
+});
+
+test('route should throw exception if no route found for name', function () {
+    $router = new Router;
+
+    expect(fn() => $router->route('non-existent-route-name'))->toThrow(Exception::class);
+});


### PR DESCRIPTION
## Description

- This introduces a method to return a route url by its name

- The main usage idea behind this is, when we want to render some href in a template we would always have to pass the full route url. With this, we can simply define a route with a name and then in the templates we only need to call app()->route('route-name') and that is it, we get the url

Let me know if this makes sense or maybe something like this already exists in the framework and I didn't found. Either way, feel free to close it if it does not make sense